### PR TITLE
missing install dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
   "requests",
   "pandas",
   "numpy",
-  "aiohttp"
+  "aiohttp",
+  "typing_extensions",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
There was one missing dependency. A fresh clone, pip install from the repo (dev mode) or a built package would fail at run time for a missing typing_extensions package missing