### PR TITLE
Add build commands before building documentations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,10 @@ build:  schema-build
 	python -m build .
 
 .PHONY: clean
-
 clean:
 	rm -rf build dist
 
-docs-build:
+docs-build: schema-build
 	cd docs && \
 	python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . ./html
 


### PR DESCRIPTION
Docs build is currently failing because the examples are missing the imports from the auto generated schema.
Adding the command to generate the schema before starting the process of building the docs