### PR TITLE
[0-feature/select model by name] - Add model selection call

### DIFF
--- a/qcog_python_client/qcog/_baseclient.py
+++ b/qcog_python_client/qcog/_baseclient.py
@@ -304,6 +304,11 @@ class BaseQcogClient:
         self.trained_model = await self.http_client.get(f"model/{guid}")
         return self
 
+    async def _preloaded_pt_model(self, model_name: str) -> BaseQcogClient:
+        self.pytorch_model = await self.http_client.get(f"pytorch_model/{model_name}")
+        self._model = ModelPytorchParameters(model_name=Model.pytorch.value)
+        return self
+
     async def _train(
         self,
         batch_size: int,

--- a/qcog_python_client/qcog/_baseclient.py
+++ b/qcog_python_client/qcog/_baseclient.py
@@ -301,7 +301,13 @@ class BaseQcogClient:
 
     async def _preloaded_model(self, guid: str) -> BaseQcogClient:
         """Retrieve preexisting model payload."""
-        self.trained_model = await self.http_client.get(f"model/{guid}")
+        if self.model.model_name == Model.pytorch.value:
+            pytorch_model_guid = self.pytorch_model["guid"]
+            self.trained_model = await self.http_client.get(
+                f"pytorch_model/{pytorch_model_guid}/trained_model/{guid}"
+            )
+        else:
+            self.trained_model = await self.http_client.get(f"model/{guid}")
         return self
 
     async def _preloaded_pt_model(self, model_name: str) -> BaseQcogClient:

--- a/qcog_python_client/qcog/qcogasync.py
+++ b/qcog_python_client/qcog/qcogasync.py
@@ -151,6 +151,22 @@ class AsyncQcogClient(BaseQcogClient):
         await self._preloaded_model(guid)
         return self
 
+    async def preloaded_pt_model(self, model_name: str) -> AsyncQcogClient:
+        """Retrieve a preexisting PyTorch model.
+
+        Parameters
+        ----------
+        model_name : str
+            model name
+
+        Returns
+        -------
+        QcogClient
+
+        """
+        await self._preloaded_pt_model(model_name)
+        return self
+
     async def train(
         self,
         batch_size: int,

--- a/qcog_python_client/qcog/qcogasync.py
+++ b/qcog_python_client/qcog/qcogasync.py
@@ -136,7 +136,10 @@ class AsyncQcogClient(BaseQcogClient):
         return self
 
     async def preloaded_model(self, guid: str) -> AsyncQcogClient:
-        """Retrieve a preexisting model.
+        """Retrieve a preexisting trained model.
+
+        If you are working on a Pytorch model, you need to preload the
+        pytorch model first using `preloaded_pt_model`.
 
         Parameters
         ----------


### PR DESCRIPTION
Add call to retrieve a model by name.
A `pytorch_model` name is unique in the scope of a project.

preload pytorch trained models with `preloaded_model`
This is in order to run cross validation against different split of the datasets or the parameters

```
*** Loading model:  titanic-03
Preloading model:  titanic-03
Loading dataset
--- Training session:  e9b56ddf-e62f-46f5-bb57-be727ddc5b98
--- Training session:  204c081b-b94e-4a15-8e66-f1bee2c18624
--- Training session:  f11e1128-a14c-4217-bd7e-45dbc646295a
============================
Runs:  ['dd2f331e-3505-395d-8e1e-4f4f8c66230f', '041d3f48-12ab-3e73-a699-b648384185a9', 'ff31cb01-77e6-3ff4-9522-c488ca1c89f9']
============================
Training finished
Metrics:  [93.22033898305085, 86.44067796610169, 84.7457627118644]
```